### PR TITLE
Adds initial podspec

### DIFF
--- a/DJProgressHUD_OSX.podspec
+++ b/DJProgressHUD_OSX.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+
+  s.name         = "DJProgressHUD_OSX"
+  s.version      = "0.0.1"
+  s.summary      = "Progress and Activity Indicators and HUD for Mac OS X."
+  s.homepage     = "https://github.com/danielmj/DJProgressHUD_OSX"
+  s.license      = { :type => "GPL", :file => "LICENSE.txt" }
+  s.author    = "Daniel Jackson"
+  s.social_media_url   = "https://github.com/danielmj"
+  s.platform     = :osx, "10.8"
+  s.source       = { :git => "https://github.com/danielmj/DJProgressHUD_OSX.git", :commit => "988334280ea95a5ef2640deebab5663b5fb24f7f" }
+
+  s.source_files  = "DJProgressHUD/*.{h,m}"
+
+  s.public_header_files = "DJProgressHUD/*.h"
+
+  s.framework  = "QuartzCore"
+
+  s.requires_arc = true
+
+end


### PR DESCRIPTION
DJProgressHUD_OSX doesn't have any version tags. I’ve added the current HEAD as version 0.0.1, but a version tag will make dependency resolution much easier.

[Semantic version](http://semver.org) tags (instead of plain commit hashes/revisions) allow for [resolution of cross-dependencies](https://github.com/CocoaPods/Specs/wiki/Cross-dependencies-resolution-example).

If you're unsure of how to create a tag; you can tag the current HEAD as, for instance, version 1.0.0, like this:

```
$ git tag -a 1.0.0 -m "Tag release 1.0.0"
$ git push --tags
```

Once you've pushed a tag, the podspec line:
````s.source       = { :git => "https://github.com/danielmj/DJProgressHUD_OSX.git", :commit => "988334280ea95a5ef2640deebab5663b5fb24f7f" }````

Will need to be changed to:
````s.source       = { :git => "https://github.com/danielmj/DJProgressHUD_OSX.git", :tag => "1.0.0" }````