### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please let me know if you find this helpfull!
 
 ##Installation
 
-**If you use Cocoapods, the feel free to add the following to your podfile:**
+**If you use CocoaPods, the feel free to add the following to your podfile:**
 
 ```
 pod 'DJProgressHUD_OSX'
@@ -21,7 +21,7 @@ pod 'DJProgressHUD_OSX'
 # pod 'DJProgressHUD_OSX', '~> X.X.X'
 ```
 
-**If you do not use Cocoapods, do the following:**
+**If you do not use CocoaPods, do the following:**
 
   1. Add DJProgressHUD to your application directory
   2. Ensure ARC is enabled on the project


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
